### PR TITLE
Ignore built styles, no build step on pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /web_modules/
 .DS_Store
 build.js
+index.css

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
         <div id="footer"></div>
 
-        <link href="./index.css" rel="stylesheet" defer>
+        <link href="./css/index.css" rel="stylesheet" defer>
         <script src="./index.js" type="module"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -14,12 +14,11 @@
     "build:js": "browserify bundle.js -o build.js -t babelify",
     "build:clean-up": "rm bundle.js",
     "build:css": "postcss css/index.css -o index.css",
-    "stylelint": "stylelint css/**/* index.css --fix",
+    "stylelint": "stylelint css/**/* --fix",
     "check": "eslint --ext=js ."
   },
   "pre-commit": [
     "check",
-    "build",
     "stylelint"
   ],
   "keywords": [


### PR DESCRIPTION
This one removes the `build` step on pre-commit.
It also moves built `index.css` to git ignore and points `index.html` to `css/index.css`

Should `/css` be top-level or should it be moved to `/src`?