### PR TITLE
Fix service name display in UI

### DIFF
--- a/templates/broadband-signup/layout/summary.js
+++ b/templates/broadband-signup/layout/summary.js
@@ -84,11 +84,11 @@ function hasContent(inputs) {
         inputs.selectedTvPackages && inputs.selectedTvPackages.length > 0);
 }
 
-function DesktopTemplate(inputs, outputs, cache, _) {
+function DesktopTemplate(inputs, outputs, cache, _local, _) {
     return DesktopSummaryWrapper(inputs, outputs, cache, _, SummaryTitle, SummaryDetails);
 }
 
-function MobileTemplate(inputs, outputs, cache, _) {
+function MobileTemplate(inputs, outputs, cache, _local, _) {
     return MobileSummaryWrapper(inputs, outputs, cache, _,
         SummaryPreview, SummaryTitle, SummaryDetails, hasContent);
 }

--- a/templates/hotel-booking/layout/summary.js
+++ b/templates/hotel-booking/layout/summary.js
@@ -80,11 +80,11 @@ function hasContent(inputs) {
     return !!inputs.selectedRooms && inputs.selectedRooms[0];
 }
 
-function DesktopTemplate(inputs, outputs, cache, _) {
+function DesktopTemplate(inputs, outputs, cache, _local, _) {
     return DesktopSummaryWrapper(inputs, outputs, cache, _, SummaryTitle, SummaryDetails);
 }
 
-function MobileTemplate(inputs, outputs, cache, _) {
+function MobileTemplate(inputs, outputs, cache, _local, _) {
     return MobileSummaryWrapper(inputs, outputs, cache, _,
         SummaryPreview, SummaryTitle, SummaryDetails, hasContent);
 }

--- a/templates/pet-insurance/layout/summary.js
+++ b/templates/pet-insurance/layout/summary.js
@@ -135,11 +135,11 @@ function hasContent(inputs) {
     return !!Object.keys(inputs).find(key => keyInputs.includes(key));
 }
 
-function DesktopTemplate(inputs, outputs, cache, _) {
+function DesktopTemplate(inputs, outputs, cache, _local, _) {
     return DesktopSummaryWrapper(inputs, outputs, cache, _, SummaryTitle, SummaryDetails);
 }
 
-function MobileTemplate(inputs, outputs, cache, _) {
+function MobileTemplate(inputs, outputs, cache, _local, _) {
     return MobileSummaryWrapper(inputs, outputs, cache, _,
         SummaryPreview, SummaryTitle, SummaryDetails, hasContent);
 }


### PR DESCRIPTION
`_local` is reserved for an end user to be able to add more info to display, e.g fallback `currencyCode`
we don't use it yet in summary, but might start using