### PR TITLE
add fillEmptyCheckboxes function in order to handle [] input case

### DIFF
--- a/src/serialize-form.js
+++ b/src/serialize-form.js
@@ -17,10 +17,10 @@ function serializeForm(selector = 'form', options = {}) {
         throw new Error('specified form not found');
     }
 
-    let serialized = formSerialize(form, { empty: false, serializer: hashSerializer, ...options });
+    const serialized = formSerialize(form, { empty: false, serializer: hashSerializer, ...options });
 
     // add empty checkboxes
-    serialized = fillEmptyInputs(form, serialized);
+    fillEmptyInputs(form, serialized);
 
     return camelCaseKeys(serialized, { deep: true });
 }
@@ -34,8 +34,6 @@ function fillEmptyInputs(form, data) {
             data[name] = [];
         }
     });
-
-    return data;
 }
 
 function getFormInputKeys(formId) {

--- a/src/serialize-form.js
+++ b/src/serialize-form.js
@@ -17,9 +17,25 @@ function serializeForm(selector = 'form', options = {}) {
         throw new Error('specified form not found');
     }
 
-    const serialized = formSerialize(form, { empty: false, serializer: hashSerializer, ...options });
+    let serialized = formSerialize(form, { empty: false, serializer: hashSerializer, ...options });
+
+    // add empty checkboxes
+    serialized = fillEmptyInputs(form, serialized);
 
     return camelCaseKeys(serialized, { deep: true });
+}
+
+function fillEmptyInputs(form, data) {
+    const checkboxes = form.querySelectorAll('input[type=checkbox]');
+
+    checkboxes.forEach(c => {
+        const name = c.name.split('-$')[0];
+        if (name && !data[name]) {
+            data[name] = [];
+        }
+    });
+
+    return data;
 }
 
 function getFormInputKeys(formId) {
@@ -186,4 +202,3 @@ function hashAssign(result, keys, value) {
 
     return result;
 }
-


### PR DESCRIPTION
This is a generic solution (a little hack) on top of the `formSerialize` lib that we use which adds in the empty `[]` input values for checkboxes where no options are selected. 

This covers `selectedMarketingContactOptions` for motor insurance domain PLUS other cases where multiple input selection is allowed.

This is a temporary solution (in the interest of time) which avoids having to roll our own or fork the `formSerialize` lib.