### PR TITLE
SDK-76 Create the app with pre-sent inputs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,13 +43,13 @@
                     throw new Error(`Unexpected response from glitch: ${res.status}`);
                 }
 
-                const { token, jobId, serviceId, supportEmail, local } = await res.json();
+                const { token, jobId, serviceId, supportEmail, local, input } = await res.json();
 
                 localStorage.setItem(`job-session`, JSON.stringify({ token, jobId, serviceId, supportEmail, local, domain }));
 
                 const sdk = createEndUserSdk({ token, jobId, serviceId });
 
-                return { sdk, supportEmail, local };
+                return { sdk, supportEmail, local, input };
             }
 
             async function init() {
@@ -97,9 +97,9 @@
                 }
 
                 const { pages, cache, layout, error } = (await import(`/templates/${domain}.config.js`)).default;
-                const { sdk, supportEmail, local } = existing || await createJob(domain);
+                const { sdk, supportEmail, local, input } = existing || await createJob(domain);
 
-                const app = createApp({ mountPoint: window.app, pages, cache, layout, sdk, error, local });
+                const app = createApp({ mountPoint: window.app, pages, cache, layout, sdk, error, local, input });
             }
 
             init();

--- a/src/main.js
+++ b/src/main.js
@@ -65,7 +65,7 @@ function validatePages(pages) {
     }
 }
 
-export async function createApp({ mountPoint, pages, cache = [], layout, error, sdk, local }, callback) {
+export async function createApp({ mountPoint, pages, cache = [], layout, error, sdk, local, input = {} }, callback) {
     validatePages(pages);
 
     try {
@@ -77,6 +77,10 @@ export async function createApp({ mountPoint, pages, cache = [], layout, error, 
     } catch (err) {
         console.error(err);
         window.location.hash = '/error';
+    }
+
+    for (const [key, data] of Object.entries(input)) {
+        Storage.set('input', key, data);
     }
 
     const mainSelector = '#main';


### PR DESCRIPTION
The client is responsible for creating the job, and there are no public endpoints to get existing inputs. It's therefore the responsibility of the client to tell the end-user which inputs the job was created with when the end-user will need these to work.

This PR updates the development index.html to expect an input field from the server, and enhances `createApp` to accept a hash of inputs to initialize itself with.