### PR TITLE
use cache instead of outputs in summary

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -74,8 +74,6 @@ export async function createApp({ mountPoint, pages, cache = [], layout, error, 
         Storage.set('input', key, data);
     }
 
-    Cache.populate(sdk, cache);
-
     const mainSelector = '#main';
 
     //setup router
@@ -115,6 +113,9 @@ export async function createApp({ mountPoint, pages, cache = [], layout, error, 
         summary.setTemplate(match ? layout.summary.MobileTemplate : layout.summary.DesktopTemplate, match);
     });
 
+    Cache.populate(sdk, cache)
+        .then(() => summary.update());
+
     const tracker = addTracker(sdk);
 
     window.addEventListener('hashchange', async () => {
@@ -148,6 +149,7 @@ export async function createApp({ mountPoint, pages, cache = [], layout, error, 
 }
 
 function afterSdkInitiated(sdk, summary, cacheConfig, local) {
+    console.info('afterSdkInitiated');
     if (local) {
         for (const [key, val] of Object.entries(local)) {
             Storage.set('local', key, val);

--- a/templates/broadband-signup.config.js
+++ b/templates/broadband-signup.config.js
@@ -36,7 +36,7 @@ export default {
         },
         {
             key: 'installationOptions',
-            sourceInputKeys: []
+            sourceInputKeys: ['selectedTvPackages']
         },
         {
             key: 'oneOffCosts',

--- a/templates/broadband-signup/layout/summary.js
+++ b/templates/broadband-signup/layout/summary.js
@@ -12,9 +12,9 @@ export default {
     }
 };
 
-function SummaryDetails({ outputs, inputs, sdk }) {
-    const priceObj = outputs.oneOffCosts && outputs.oneOffCosts.contents.find(o => o.name.match(/pay now/i));
-    const next = outputs.oneOffCosts && outputs.oneOffCosts.contents.find(o => o.name.match(/next bill/i));
+function SummaryDetails({ outputs, inputs, cache, sdk }) {
+    const priceObj = cache.oneOffCosts && cache.oneOffCosts.contents.find(o => o.name.match(/pay now/i));
+    const next = cache.oneOffCosts && cache.oneOffCosts.contents.find(o => o.name.match(/next bill/i));
     const selectedTvPackages = inputs.selectedTvPackages && inputs.selectedTvPackages.map(_ => _.name).join(', ');
 
     return html`
@@ -46,12 +46,12 @@ function SummaryDetails({ outputs, inputs, sdk }) {
             </ul>
         </article>
 
-        ${outputs.oneOffCosts ? html`
-            <h4>${outputs.oneOffCosts.name}</h4>
+        ${cache.oneOffCosts ? html`
+            <h4>${cache.oneOffCosts.name}</h4>
             <article class="summary__block summary__block--bordered">
 
                 <table class="table">
-                    ${outputs.oneOffCosts.contents.map(o => html`
+                    ${cache.oneOffCosts.contents.map(o => html`
                         <tr>
                             <th>${o.name}</th>
                             <td>${templates.priceDisplay(o.price)}</td>
@@ -60,12 +60,12 @@ function SummaryDetails({ outputs, inputs, sdk }) {
             </article>` : ''}
 
 
-        ${outputs.monthlyCosts ? html`
-            <h4>${outputs.monthlyCosts.name}</h4>
+        ${cache.monthlyCosts ? html`
+            <h4>${cache.monthlyCosts.name}</h4>
             <article class="summary__block summary__block--bordered">
 
                 <table class="table">
-                    ${outputs.monthlyCosts.contents.map(o => html`
+                    ${cache.monthlyCosts.contents.map(o => html`
                         <tr>
                             <th>${o.name}</th>
                             <td>${templates.priceDisplay(o.price)}</td>


### PR DESCRIPTION
this PR adjusts the summary to use cache instead of outputs for the price breakdown. It shows an issue where the summary only shows the breakdown after user enters postcode. It should display the price breakdown immediately.