### PR TITLE
Add scroll when form content finished to load (button shown)

### DIFF
--- a/src/page-renderer.js
+++ b/src/page-renderer.js
@@ -87,6 +87,8 @@ class PageRenderer {
 
         const sectionForm = document.querySelector(`#section-form-${elementName}`);
 
+        sectionForm.scrollIntoView(true);
+
         submitBtn.addEventListener('click', e => {
             flashError().hide();
 


### PR DESCRIPTION
Additional scroll friction when the form's content is loaded (button is shown) 

So it works this way:
1. scroll form's container into view when the next section started to load (user observes a loading indicator) 
2. scroll it again when form's content displayed 